### PR TITLE
Add horizontal mouse wheel scroll

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -718,6 +718,10 @@ mouseProtoSend (MouseTrackingEnc enc, int eventType, unsigned int modstate,
          cb = 64; // Mouse wheel up
       else if (button == 5)
          cb = 65; // Mouse wheel down
+      else if (button == 6)
+         cb = 66; // Mouse wheel left
+      else if (button == 7)
+         cb = 67; // Mouse wheel right
       else
          cb = button - 1; // Mouse button 1..3
    }
@@ -766,7 +770,7 @@ onButtonPressMouseProto (XButtonEvent& xbevt,
 {
    uint16_t cx, cy;
 
-   if (xbevt.button > 5)
+   if (xbevt.button > 7)
       return;
 
    switch (mouseTrk.mode)


### PR DESCRIPTION
Fixes that, for example, the `<ScrollWheelLeft>` and `<ScrollWheelRight>` events do not come to the vim editor.

https://user-images.githubusercontent.com/18342621/212151037-a387c000-1995-4ed0-9761-1bc66b2c09ed.mp4

Actually this PR is more of a question, because I don't understand it, I just looked at it in the debugger and added something, to make it work.