### PR TITLE
Remove deprecated key from desktop file

### DIFF
--- a/icons/zutty.desktop
+++ b/icons/zutty.desktop
@@ -1,6 +1,5 @@
 [Desktop Entry]
 Type=Application
-Encoding=UTF-8
 Name=Zutty
 Comment=Zero-cost Unicode Teletype
 Exec=zutty


### PR DESCRIPTION
The "Encoding" key is deprecated in latest specification: https://specifications.freedesktop.org/desktop-entry-spec/latest/apc.html