### PR TITLE
Improve default font search path for NetBSD.

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -39,6 +39,8 @@ namespace zutty
 
 #if defined(FREEBSD)
    static constexpr const char* fontpath = "/usr/local/share/fonts";
+#elif defined(NETBSD)
+   static constexpr const char* fontpath = "/usr/X11R7/lib/X11/fonts";
 #elif defined(OPENBSD)
    static constexpr const char* fontpath = "/usr/X11R6/lib/X11/fonts";
 #else

--- a/wscript
+++ b/wscript
@@ -54,7 +54,7 @@ def configure(cfg):
                              ['-DBSD', '-DOPENBSD', '-I/usr/X11R6/include'])
         cfg.env.append_value('LINKFLAGS', ['-L/usr/X11R6/lib'])
     elif platform == 'NetBSD':
-        cfg.env.append_value('CXXFLAGS', ['-DBSD'])
+        cfg.env.append_value('CXXFLAGS', ['-DBSD', '-DNETBSD'])
     elif platform == 'Darwin':
         cfg.env.append_value('CXXFLAGS', ['-DMACOS'])
     elif platform == 'SunOS':


### PR DESCRIPTION
I've packaged zutty for pkgsrc and just had to change the default font search path to make it start.